### PR TITLE
k8s sb fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_ALL_CODEBASE: true
+          VALIDATE_PYTHON_MYPY: false
           LINTER_RULES_PATH: .
           PYTHON_BLACK_CONFIG_FILE: pyproject.toml
           PYTHON_ISORT_CONFIG_FILE: pyproject.toml

--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -219,7 +219,7 @@ def wait_and_delete_temp_branch(
 
         with yaspin(text="Starting...", color="yellow") as spinner:
             while (datetime.datetime.now() - start_time).seconds < TIMEOUT * 60:
-                if (status in FINAL_SB_STATUSES) or can_temp_branch_be_delete(sandbox,k8s_blueprint):
+                if (status in FINAL_SB_STATUSES) or can_temp_branch_be_delete(sandbox, k8s_blueprint):
                     spinner.green.ok("✔")
                     delete_temp_branch(repo, temp_branch)
                     break
@@ -255,13 +255,13 @@ def revert_and_delete_temp_branch(
 
 
 def revert_wait_and_delete_temp_branch(
-        manager: SandboxesManager,
-        blueprint_name: str,
-        repo: BlueprintRepo,
-        sandbox_id: str,
-        stashed_flag: bool,
-        temp_working_branch: str,
-        working_branch: str
+    manager: SandboxesManager,
+    blueprint_name: str,
+    repo: BlueprintRepo,
+    sandbox_id: str,
+    stashed_flag: bool,
+    temp_working_branch: str,
+    working_branch: str
 ) -> None:
     if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
         revert_from_temp_branch(repo, working_branch, stashed_flag)
@@ -275,9 +275,9 @@ def can_temp_branch_be_delete(sandbox: Sandbox, k8s_blueprint: bool) -> bool:
     creating_infra_status = progress.get("creating_infrastructure").get("status")
 
     not_k8s_sb_deployed = not k8s_blueprint and prep_artifacts_status != "Pending"
-    k8s_sb_done_statuses = creating_infra_status == "Done" and \
-                           prep_artifacts_status == "Done" and \
-                           deploy_app_status == "Done"
-    k8s_sb_deployed = k8s_blueprint and  k8s_sb_done_statuses
+    k8s_sb_done_statuses = (
+        creating_infra_status == "Done" and prep_artifacts_status == "Done" and deploy_app_status == "Done"
+    )
+    k8s_sb_deployed = k8s_blueprint and k8s_sb_done_statuses
 
     return not_k8s_sb_deployed or k8s_sb_deployed

--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -212,6 +212,7 @@ def wait_and_delete_temp_branch(
         progress = getattr(sandbox, "launching_progress")
         prep_art_status = progress.get("preparing_artifacts").get("status")
         deploy_app_status = progress.get("deploying_applications").get("status")
+        creating_infra_status = progress.get("creating_infrastructure").get("status")
         logger.debug(
             "Waiting for sandbox (id={}) to be provisioned (before deleting temp branch)...".format(sandbox_id)
         )
@@ -226,7 +227,9 @@ def wait_and_delete_temp_branch(
                     or prep_art_status != "Pending"
                     and not k8s_blueprint
                     or k8s_blueprint
-                    and deploy_app_status != "Pending"
+                    and creating_infra_status == "Done"
+                    and prep_art_status == "Done"
+                    and deploy_app_status == "Done"
                 ):
                     spinner.green.ok("✔")
                     delete_temp_branch(repo, temp_branch)
@@ -237,6 +240,7 @@ def wait_and_delete_temp_branch(
                 sandbox = sb_manager.get(sandbox_id)
                 status = getattr(sandbox, "sandbox_status")
                 progress = getattr(sandbox, "launching_progress")
+                creating_infra_status = progress.get("creating_infrastructure").get("status")
                 prep_art_status = progress.get("preparing_artifacts").get("status")
                 deploy_app_status = progress.get("deploying_applications").get("status")
     except Exception as e:

--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -8,7 +8,7 @@ import time
 from yaspin import yaspin
 
 from colony.commands.base import BaseCommand
-from colony.constants import FINAL_SB_STATUSES, TIMEOUT, UNCOMMITTED_BRANCH_NAME, DONE_STATUS
+from colony.constants import DONE_STATUS, FINAL_SB_STATUSES, TIMEOUT, UNCOMMITTED_BRANCH_NAME
 from colony.exceptions import BadBlueprintRepo
 from colony.sandboxes import Sandbox, SandboxesManager
 from colony.utils import BlueprintRepo
@@ -230,6 +230,7 @@ def wait_and_delete_temp_branch(
 
     finally:
         delete_temp_branch(repo, temp_branch)
+
 
 def is_k8s_blueprint(blueprint_name: str, repo: BlueprintRepo) -> bool:
     k8s_sandbox_flag = False

--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -212,17 +212,22 @@ def wait_and_delete_temp_branch(
         progress = getattr(sandbox, "launching_progress")
         prep_art_status = progress.get("preparing_artifacts").get("status")
         deploy_app_status = progress.get("deploying_applications").get("status")
-        logger.debug("Waiting for sandbox (id={}) to be provisioned"
-                     " (before deleting temp branch)...".format(sandbox_id))
+        logger.debug(
+            "Waiting for sandbox (id={}) to be provisioned (before deleting temp branch)...".format(sandbox_id)
+        )
 
         BaseCommand.info("Waiting for the Sandbox to start with local changes. This may take some time.")
         BaseCommand.fyi_info("Canceling or exiting before the process completes may cause the sandbox to fail")
 
         with yaspin(text="Starting...", color="yellow") as spinner:
             while (datetime.datetime.now() - start_time).seconds < TIMEOUT * 60:
-                if status in FINAL_SB_STATUSES or \
-                        prep_art_status != "Pending" and not k8s_blueprint or \
-                        k8s_blueprint and deploy_app_status != "Pending":
+                if (
+                        status in FINAL_SB_STATUSES
+                        or prep_art_status != "Pending"
+                        and not k8s_blueprint
+                        or k8s_blueprint
+                        and deploy_app_status != "Pending"
+                ):
                     spinner.green.ok("✔")
                     delete_temp_branch(repo, temp_branch)
                     break
@@ -242,7 +247,7 @@ def wait_and_delete_temp_branch(
 def is_k8s_blueprint(blueprint_name, repo) -> bool:
     k8s_sandbox_flag = False
     yaml_obj = repo.get_blueprint_yaml(blueprint_name)
-    for cloud in yaml_obj['clouds']:
+    for cloud in yaml_obj["clouds"]:
         if "/" in cloud:
             k8s_sandbox_flag = True
     return k8s_sandbox_flag

--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -248,7 +248,7 @@ def wait_and_delete_temp_branch(
         delete_temp_branch(repo, temp_branch)
 
 
-def is_k8s_blueprint(blueprint_name, repo) -> bool:
+def is_k8s_blueprint(blueprint_name: str, repo: BlueprintRepo) -> bool:
     k8s_sandbox_flag = False
     yaml_obj = repo.get_blueprint_yaml(blueprint_name)
     for cloud in yaml_obj["clouds"]:
@@ -257,7 +257,7 @@ def is_k8s_blueprint(blueprint_name, repo) -> bool:
     return k8s_sandbox_flag
 
 
-def checkout_remote_branch(repo: BlueprintRepo, active_branch: str):
+def checkout_remote_branch(repo: BlueprintRepo, active_branch: str) -> None:
     logger.debug(f"[GIT] Checking out {active_branch}")
     repo.git.checkout(active_branch)
 
@@ -268,3 +268,17 @@ def revert_and_delete_temp_branch(
     if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
         revert_from_temp_branch(repo, working_branch, stashed_flag)
         delete_temp_branch(repo, temp_working_branch)
+
+
+def revert_wait_and_delete_temp_branch(
+        manager: SandboxesManager,
+        blueprint_name: str,
+        repo: BlueprintRepo,
+        sandbox_id: str,
+        stashed_flag: bool,
+        temp_working_branch: str,
+        working_branch: str
+) -> None:
+    if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
+        revert_from_temp_branch(repo, working_branch, stashed_flag)
+        wait_and_delete_temp_branch(manager, sandbox_id, repo, temp_working_branch, blueprint_name)

--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -274,9 +274,9 @@ def can_temp_branch_be_deleted(sandbox: Sandbox, k8s_blueprint: bool) -> bool:
     creating_infra_status = progress.get("creating_infrastructure").get("status")
 
     k8s_sb_done_statuses = (
-        creating_infra_status == DONE_STATUS and
-        prep_artifacts_status == DONE_STATUS and
-        deploy_app_status == DONE_STATUS
+        creating_infra_status == DONE_STATUS
+        and prep_artifacts_status == DONE_STATUS
+        and deploy_app_status == DONE_STATUS
     )
 
     if k8s_blueprint:

--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -222,11 +222,11 @@ def wait_and_delete_temp_branch(
         with yaspin(text="Starting...", color="yellow") as spinner:
             while (datetime.datetime.now() - start_time).seconds < TIMEOUT * 60:
                 if (
-                        status in FINAL_SB_STATUSES
-                        or prep_art_status != "Pending"
-                        and not k8s_blueprint
-                        or k8s_blueprint
-                        and deploy_app_status != "Pending"
+                    status in FINAL_SB_STATUSES
+                    or prep_art_status != "Pending"
+                    and not k8s_blueprint
+                    or k8s_blueprint
+                    and deploy_app_status != "Pending"
                 ):
                     spinner.green.ok("✔")
                     delete_temp_branch(repo, temp_branch)

--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -224,6 +224,7 @@ def wait_and_delete_temp_branch(
                 time.sleep(10)
                 spinner.text = f"[{int((datetime.datetime.now() - start_time).total_seconds())} sec]"
                 sandbox = sb_manager.get(sandbox_id)
+                status = getattr(sandbox, "sandbox_status")
 
     except Exception as e:
         logger.error(f"There was an issue with waiting for sandbox deployment -> {str(e)}")

--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -261,7 +261,7 @@ def revert_wait_and_delete_temp_branch(
     sandbox_id: str,
     stashed_flag: bool,
     temp_working_branch: str,
-    working_branch: str
+    working_branch: str,
 ) -> None:
     if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
         revert_from_temp_branch(repo, working_branch, stashed_flag)

--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -225,6 +225,8 @@ def wait_and_delete_temp_branch(
                 spinner.text = f"[{int((datetime.datetime.now() - start_time).total_seconds())} sec]"
                 sandbox = sb_manager.get(sandbox_id)
                 status = getattr(sandbox, "sandbox_status")
+            else:
+                logger.debug("Timeout Reached")
 
     except Exception as e:
         logger.error(f"There was an issue with waiting for sandbox deployment -> {str(e)}")

--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -10,7 +10,7 @@ from yaspin import yaspin
 from colony.commands.base import BaseCommand
 from colony.constants import FINAL_SB_STATUSES, TIMEOUT, UNCOMMITTED_BRANCH_NAME
 from colony.exceptions import BadBlueprintRepo
-from colony.sandboxes import SandboxesManager, Sandbox
+from colony.sandboxes import Sandbox, SandboxesManager
 from colony.utils import BlueprintRepo
 
 logging.getLogger("git").setLevel(logging.WARNING)
@@ -83,7 +83,7 @@ def figure_out_branches(user_defined_branch: str, blueprint_name: str):
                 )
                 logger.debug(
                     f"Using temp branch: {temp_working_branch} "
-                    f"(This shall include any uncommitted changes but and/or untracked files)"
+                    f"(This shall include any uncommitted changes and/or untracked files)"
                 )
             except Exception as e:
                 logger.error(f"Was not able push your latest changes to temp branch for validation. Reason: {str(e)}")

--- a/colony/commands/sb.py
+++ b/colony/commands/sb.py
@@ -6,7 +6,10 @@ import time
 import tabulate
 from docopt import DocoptExit
 
-from colony.branch_utils import figure_out_branches, revert_from_temp_branch, wait_and_then_delete_branch
+from colony.branch_utils import figure_out_branches, \
+    revert_from_temp_branch, \
+    wait_and_delete_temp_branch, \
+    delete_temp_branch
 from colony.commands.base import BaseCommand
 from colony.constants import UNCOMMITTED_BRANCH_NAME
 from colony.sandboxes import SandboxesManager
@@ -192,6 +195,8 @@ class SandboxesCommand(BaseCommand):
         except Exception as e:
             logger.exception(e, exc_info=False)
             sandbox_id = None
+            if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
+                delete_temp_branch(repo, temp_working_branch)
             return self.die()
         finally:
             logger.debug("Cleaning up")
@@ -200,7 +205,8 @@ class SandboxesCommand(BaseCommand):
 
         # todo: I think the below can be simplified and refactored
         if timeout is None:
-            wait_and_then_delete_branch(self.manager, sandbox_id, repo, temp_working_branch)
+            if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
+                wait_and_delete_temp_branch(self.manager, sandbox_id, repo, temp_working_branch, blueprint_name)
             return self.success("The Sandbox was created")
 
         else:
@@ -221,10 +227,13 @@ class SandboxesCommand(BaseCommand):
                     time.sleep(30)
 
                 else:
-                    wait_and_then_delete_branch(self.manager, sandbox_id, repo, temp_working_branch)
+                    blueprint_name = self.args.get("<name>")
+                    if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
+                        wait_and_delete_temp_branch(self.manager, sandbox_id, repo, temp_working_branch, blueprint_name)
                     return self.die(f"The Sandbox {sandbox_id} has started. Current state is: {status}")
 
             # timeout exceeded
             logger.error(f"Sandbox {sandbox_id} was not active after the provided timeout of {timeout} minutes")
-            wait_and_then_delete_branch(self.manager, sandbox_id, repo, temp_working_branch)
+            if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
+                wait_and_delete_temp_branch(self.manager, sandbox_id, repo, temp_working_branch, blueprint_name)
             return self.die()

--- a/colony/commands/sb.py
+++ b/colony/commands/sb.py
@@ -204,8 +204,9 @@ class SandboxesCommand(BaseCommand):
 
         # todo: I think the below can be simplified and refactored
         if timeout is None:
-            revert_wait_and_delete_temp_branch(self.manager, blueprint_name, repo, sandbox_id, stashed_flag,
-                                               temp_working_branch, working_branch)
+            revert_wait_and_delete_temp_branch(
+                self.manager, blueprint_name, repo, sandbox_id, stashed_flag, temp_working_branch, working_branch
+            )
             return self.success("The Sandbox was created")
 
         else:
@@ -227,12 +228,20 @@ class SandboxesCommand(BaseCommand):
 
                 else:
                     blueprint_name = self.args.get("<name>")
-                    revert_wait_and_delete_temp_branch(self.manager, blueprint_name, repo, sandbox_id, stashed_flag,
-                                                       temp_working_branch, working_branch)
+                    revert_wait_and_delete_temp_branch(
+                        self.manager,
+                        blueprint_name,
+                        repo,
+                        sandbox_id,
+                        stashed_flag,
+                        temp_working_branch,
+                        working_branch,
+                    )
                     return self.die(f"The Sandbox {sandbox_id} has started. Current state is: {status}")
 
             # timeout exceeded
             logger.error(f"Sandbox {sandbox_id} was not active after the provided timeout of {timeout} minutes")
-            revert_wait_and_delete_temp_branch(self.manager, blueprint_name, repo, sandbox_id, stashed_flag,
-                                               temp_working_branch, working_branch)
+            revert_wait_and_delete_temp_branch(
+                self.manager, blueprint_name, repo, sandbox_id, stashed_flag, temp_working_branch,working_branch
+            )
             return self.die()

--- a/colony/commands/sb.py
+++ b/colony/commands/sb.py
@@ -242,6 +242,6 @@ class SandboxesCommand(BaseCommand):
             # timeout exceeded
             logger.error(f"Sandbox {sandbox_id} was not active after the provided timeout of {timeout} minutes")
             revert_wait_and_delete_temp_branch(
-                self.manager, blueprint_name, repo, sandbox_id, stashed_flag, temp_working_branch,working_branch
+                self.manager, blueprint_name, repo, sandbox_id, stashed_flag, temp_working_branch, working_branch
             )
             return self.die()

--- a/colony/commands/sb.py
+++ b/colony/commands/sb.py
@@ -198,16 +198,14 @@ class SandboxesCommand(BaseCommand):
             logger.exception(e, exc_info=False)
             sandbox_id = None
             if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
+                revert_from_temp_branch(repo, working_branch, stashed_flag)
                 delete_temp_branch(repo, temp_working_branch)
             return self.die()
-        finally:
-            logger.debug("Cleaning up")
-            if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
-                revert_from_temp_branch(repo, working_branch, stashed_flag)
 
         # todo: I think the below can be simplified and refactored
         if timeout is None:
             if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
+                revert_from_temp_branch(repo, working_branch, stashed_flag)
                 wait_and_delete_temp_branch(self.manager, sandbox_id, repo, temp_working_branch, blueprint_name)
             return self.success("The Sandbox was created")
 
@@ -231,11 +229,13 @@ class SandboxesCommand(BaseCommand):
                 else:
                     blueprint_name = self.args.get("<name>")
                     if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
+                        revert_from_temp_branch(repo, working_branch, stashed_flag)
                         wait_and_delete_temp_branch(self.manager, sandbox_id, repo, temp_working_branch, blueprint_name)
                     return self.die(f"The Sandbox {sandbox_id} has started. Current state is: {status}")
 
             # timeout exceeded
             logger.error(f"Sandbox {sandbox_id} was not active after the provided timeout of {timeout} minutes")
             if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
+                revert_from_temp_branch(repo, working_branch, stashed_flag)
                 wait_and_delete_temp_branch(self.manager, sandbox_id, repo, temp_working_branch, blueprint_name)
             return self.die()

--- a/colony/commands/sb.py
+++ b/colony/commands/sb.py
@@ -6,10 +6,12 @@ import time
 import tabulate
 from docopt import DocoptExit
 
-from colony.branch_utils import figure_out_branches, \
-    revert_from_temp_branch, \
-    wait_and_delete_temp_branch, \
-    delete_temp_branch
+from colony.branch_utils import (
+    delete_temp_branch,
+    figure_out_branches,
+    revert_from_temp_branch,
+    wait_and_delete_temp_branch,
+)
 from colony.commands.base import BaseCommand
 from colony.constants import UNCOMMITTED_BRANCH_NAME
 from colony.sandboxes import SandboxesManager

--- a/colony/commands/sb.py
+++ b/colony/commands/sb.py
@@ -10,7 +10,7 @@ from colony.branch_utils import (
     delete_temp_branch,
     figure_out_branches,
     revert_from_temp_branch,
-    wait_and_delete_temp_branch,
+    revert_wait_and_delete_temp_branch,
 )
 from colony.commands.base import BaseCommand
 from colony.constants import UNCOMMITTED_BRANCH_NAME
@@ -204,9 +204,8 @@ class SandboxesCommand(BaseCommand):
 
         # todo: I think the below can be simplified and refactored
         if timeout is None:
-            if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
-                revert_from_temp_branch(repo, working_branch, stashed_flag)
-                wait_and_delete_temp_branch(self.manager, sandbox_id, repo, temp_working_branch, blueprint_name)
+            revert_wait_and_delete_temp_branch(self.manager, blueprint_name, repo, sandbox_id, stashed_flag,
+                                               temp_working_branch, working_branch)
             return self.success("The Sandbox was created")
 
         else:
@@ -228,14 +227,12 @@ class SandboxesCommand(BaseCommand):
 
                 else:
                     blueprint_name = self.args.get("<name>")
-                    if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
-                        revert_from_temp_branch(repo, working_branch, stashed_flag)
-                        wait_and_delete_temp_branch(self.manager, sandbox_id, repo, temp_working_branch, blueprint_name)
+                    revert_wait_and_delete_temp_branch(self.manager, blueprint_name, repo, sandbox_id, stashed_flag,
+                                                       temp_working_branch, working_branch)
                     return self.die(f"The Sandbox {sandbox_id} has started. Current state is: {status}")
 
             # timeout exceeded
             logger.error(f"Sandbox {sandbox_id} was not active after the provided timeout of {timeout} minutes")
-            if temp_working_branch.startswith(UNCOMMITTED_BRANCH_NAME):
-                revert_from_temp_branch(repo, working_branch, stashed_flag)
-                wait_and_delete_temp_branch(self.manager, sandbox_id, repo, temp_working_branch, blueprint_name)
+            revert_wait_and_delete_temp_branch(self.manager, blueprint_name, repo, sandbox_id, stashed_flag,
+                                               temp_working_branch, working_branch)
             return self.die()

--- a/colony/constants.py
+++ b/colony/constants.py
@@ -4,6 +4,7 @@ FINAL_SB_STATUSES = ["Active", "ActiveWithError", "Ended", "EndedWithError", "En
 
 DONE_STATUS = "Done"
 
+
 class ConstantBase:
     def __new__(cls, *args, **kwargs):
         raise TypeError("Constants class cannot be instantiated")

--- a/colony/constants.py
+++ b/colony/constants.py
@@ -2,6 +2,7 @@ UNCOMMITTED_BRANCH_NAME = "tmp-colony-"
 TIMEOUT = 30
 FINAL_SB_STATUSES = ["Active", "ActiveWithError", "Ended", "EndedWithError", "Ending"]
 
+DONE_STATUS = "Done"
 
 class ConstantBase:
     def __new__(cls, *args, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 docopt==0.6.2
-requests
-setuptools
+requests==2.25.1
+setuptools==54.2.0
 gitpython==3.1.12
 pyyaml==5.4.1
 tabulate==0.8.7
 colorama==0.4.3
 yaspin==1.4.1
 semantic-version==2.8.5
+freezegun==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ tabulate==0.8.7
 colorama==0.4.3
 yaspin==1.4.1
 semantic-version==2.8.5
-freezegun==1.1.0

--- a/tests/test_branch_utils.py
+++ b/tests/test_branch_utils.py
@@ -1,14 +1,19 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from datetime import datetime
+from unittest.mock import patch, Mock
 
 from colony import branch_utils
-from colony.constants import UNCOMMITTED_BRANCH_NAME
+from colony.constants import UNCOMMITTED_BRANCH_NAME, FINAL_SB_STATUSES
+from colony.exceptions import BadBlueprintRepo
+from freezegun import freeze_time
 
 
 class TestStashLogicFunctions(unittest.TestCase):
     def setUp(self):
         self.switch = branch_utils.switch_to_temp_branch
         self.revert = branch_utils.revert_from_temp_branch
+        self.examine = branch_utils.examine_blueprint_working_branch
+        self.wait_and_delete = branch_utils.wait_and_delete_temp_branch
 
     @patch.object(branch_utils, "create_remote_branch")
     @patch.object(branch_utils, "commit_to_local_temp_branch")
@@ -24,9 +29,9 @@ class TestStashLogicFunctions(unittest.TestCase):
         create_remote_branch,
     ):
         # Arrange:
-        mock_repo = MagicMock()
-        mock_repo.is_dirty = MagicMock(return_value=True)
-        defined_branch_in_file = MagicMock()
+        mock_repo = Mock()
+        mock_repo.is_dirty = Mock(return_value=True)
+        defined_branch_in_file = "defined_branch_in_file"
         # Act:
         uncommitted_branch_name, flag = self.switch(mock_repo, defined_branch_in_file)
         # Assert:
@@ -51,10 +56,10 @@ class TestStashLogicFunctions(unittest.TestCase):
         create_remote_branch,
     ):
         # Arrange:
-        mock_repo = MagicMock()
-        mock_repo.is_dirty = MagicMock(return_value=False)
+        mock_repo = Mock()
+        mock_repo.is_dirty = Mock(return_value=False)
         mock_repo.untracked_files = True
-        defined_branch_in_file = MagicMock()
+        defined_branch_in_file = "defined_branch_in_file"
         # Act:
         uncommitted_branch_name, flag = self.switch(mock_repo, defined_branch_in_file)
         # Assert:
@@ -69,7 +74,7 @@ class TestStashLogicFunctions(unittest.TestCase):
     @patch.object(branch_utils, "revert_from_uncommitted_code")
     def test_revert_from_temp_branch(self, revert_from_uncommitted_code, checkout_remote_branch):
         # Arrange:
-        mock_repo = MagicMock()
+        mock_repo = Mock()
         active_branch = "active_branch"
         # Act:
         self.revert(mock_repo, active_branch, True)
@@ -79,3 +84,50 @@ class TestStashLogicFunctions(unittest.TestCase):
             active_branch,
         )
         revert_from_uncommitted_code.assert_called_once_with(mock_repo)
+
+
+    def test_examine_blueprint_working_branch_detached(self):
+        # Arrange:
+        mock_repo = Mock()
+        mock_blueprint = Mock()
+        mock_repo.is_repo_detached = Mock(return_value=True)
+
+        # Act:
+        #self.examine(mock_repo,mock_blueprint)
+
+        # Assert:
+        self.assertRaises(BadBlueprintRepo, self.examine, mock_repo, mock_blueprint)
+
+    def test_examine_blueprint_working_branch_attached(self):
+        # Arrange:
+        mock_repo = Mock()
+        mock_blueprint = Mock()
+        mock_repo.is_repo_detached = Mock(return_value=False)
+
+        # Act:
+        self.examine(mock_repo,mock_blueprint)
+
+        # Assert:
+        mock_repo.is_dirty.assert_called_once()
+        mock_repo.is_current_branch_exists_on_remote()
+        mock_repo.is_current_branch_synced()
+
+    @freeze_time(datetime.now())
+    @patch.object(branch_utils, "is_k8s_blueprint")
+    @patch.object(branch_utils, "can_temp_branch_be_deleted")
+    @patch.object(branch_utils, "delete_temp_branch")
+    def test_wait_and_delete_temp_branch_not_k8s(self, delete_temp_branch, can_temp, is_k8s_blueprint):
+        # Arrange:
+        mock_sb_manager = Mock()
+        mock_sandbox_id = "mock_sandbox_id"
+        mock_temp_branch = "mock_temp_branch"
+        mock_blueprint_name = "mock_blueprint_name"
+
+        is_k8s_blueprint = Mock(return_value=False)
+        can_temp = Mock(return_value=False)
+
+        # Act & assert:
+        for final_stage in FINAL_SB_STATUSES:
+            mock_repo = Mock(sandbox_status=final_stage)
+            self.wait_and_delete(mock_sb_manager, mock_sandbox_id, mock_repo, mock_temp_branch, mock_blueprint_name)
+            delete_temp_branch.assert_called_with(mock_repo, mock_temp_branch)

--- a/tests/test_branch_utils.py
+++ b/tests/test_branch_utils.py
@@ -3,8 +3,9 @@ from datetime import datetime
 from unittest.mock import Mock, patch
 
 from freezegun import freeze_time
+
 from colony import branch_utils
-from colony.constants import UNCOMMITTED_BRANCH_NAME, FINAL_SB_STATUSES
+from colony.constants import FINAL_SB_STATUSES, UNCOMMITTED_BRANCH_NAME
 from colony.exceptions import BadBlueprintRepo
 
 

--- a/tests/test_branch_utils.py
+++ b/tests/test_branch_utils.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from unittest.mock import Mock, patch
 
 from colony import branch_utils
-from colony.constants import FINAL_SB_STATUSES, UNCOMMITTED_BRANCH_NAME, TIMEOUT
+from colony.constants import FINAL_SB_STATUSES, TIMEOUT, UNCOMMITTED_BRANCH_NAME
 from colony.exceptions import BadBlueprintRepo
 
 
@@ -118,7 +118,7 @@ class TestStashLogicFunctions(unittest.TestCase):
         self.repo.is_current_branch_exists_on_remote()
         self.repo.is_current_branch_synced()
 
-    @patch('time.sleep', return_value=None)
+    @patch("time.sleep", return_value=None)
     @patch("colony.branch_utils.is_k8s_blueprint")
     @patch("colony.branch_utils.can_temp_branch_be_deleted")
     @patch("colony.branch_utils.delete_temp_branch")
@@ -136,7 +136,7 @@ class TestStashLogicFunctions(unittest.TestCase):
             assert (datetime.now() - start_time).seconds < TIMEOUT * 60
             delete_temp_branch.assert_called_with(self.repo, self.temp_branch)
 
-    @patch('time.sleep', return_value=None)
+    @patch("time.sleep", return_value=None)
     @patch("colony.branch_utils.is_k8s_blueprint")
     @patch("colony.branch_utils.can_temp_branch_be_deleted")
     @patch("colony.branch_utils.delete_temp_branch")

--- a/tests/test_branch_utils.py
+++ b/tests/test_branch_utils.py
@@ -1,11 +1,11 @@
 import unittest
 from datetime import datetime
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
+from freezegun import freeze_time
 from colony import branch_utils
 from colony.constants import UNCOMMITTED_BRANCH_NAME, FINAL_SB_STATUSES
 from colony.exceptions import BadBlueprintRepo
-from freezegun import freeze_time
 
 
 class TestStashLogicFunctions(unittest.TestCase):
@@ -84,7 +84,6 @@ class TestStashLogicFunctions(unittest.TestCase):
             active_branch,
         )
         revert_from_uncommitted_code.assert_called_once_with(mock_repo)
-
 
     def test_examine_blueprint_working_branch_detached(self):
         # Arrange:

--- a/tests/test_branch_utils.py
+++ b/tests/test_branch_utils.py
@@ -2,10 +2,8 @@ import unittest
 from datetime import datetime
 from unittest.mock import Mock, patch
 
-from freezegun import freeze_time
-
 from colony import branch_utils
-from colony.constants import FINAL_SB_STATUSES, UNCOMMITTED_BRANCH_NAME
+from colony.constants import FINAL_SB_STATUSES, UNCOMMITTED_BRANCH_NAME, TIMEOUT
 from colony.exceptions import BadBlueprintRepo
 
 
@@ -15,6 +13,17 @@ class TestStashLogicFunctions(unittest.TestCase):
         self.revert = branch_utils.revert_from_temp_branch
         self.examine = branch_utils.examine_blueprint_working_branch
         self.wait_and_delete = branch_utils.wait_and_delete_temp_branch
+
+        self.initialize_mock_vars()
+
+    def initialize_mock_vars(self):
+        self.repo = Mock()
+        self.sb_manager = Mock()
+        self.sandbox = Mock()
+        self.sb_manager.get.return_value = self.sandbox
+        self.sandbox_id = Mock()
+        self.temp_branch = "mock_temp_branch"
+        self.blueprint_name = "mock_blueprint_name"
 
     @patch.object(branch_utils, "create_remote_branch")
     @patch.object(branch_utils, "commit_to_local_temp_branch")
@@ -30,17 +39,17 @@ class TestStashLogicFunctions(unittest.TestCase):
         create_remote_branch,
     ):
         # Arrange:
-        mock_repo = Mock()
-        mock_repo.is_dirty = Mock(return_value=True)
+        self.repo = Mock()
+        self.repo.is_dirty = Mock(return_value=True)
         defined_branch_in_file = "defined_branch_in_file"
         # Act:
-        uncommitted_branch_name, flag = self.switch(mock_repo, defined_branch_in_file)
+        uncommitted_branch_name, flag = self.switch(self.repo, defined_branch_in_file)
         # Assert:
-        create_remote_branch.assert_called_once_with(mock_repo, uncommitted_branch_name)
-        commit_to_local_temp_branch.assert_called_once_with(mock_repo)
-        preserve_uncommitted_code.assert_called_once_with(mock_repo)
-        create_local_temp_branch.assert_called_once_with(mock_repo, uncommitted_branch_name)
-        stash_local_changes.assert_called_once_with(mock_repo)
+        create_remote_branch.assert_called_once_with(self.repo, uncommitted_branch_name)
+        commit_to_local_temp_branch.assert_called_once_with(self.repo)
+        preserve_uncommitted_code.assert_called_once_with(self.repo)
+        create_local_temp_branch.assert_called_once_with(self.repo, uncommitted_branch_name)
+        stash_local_changes.assert_called_once_with(self.repo)
         self.assertTrue(uncommitted_branch_name.startswith(UNCOMMITTED_BRANCH_NAME))
 
     @patch.object(branch_utils, "create_remote_branch")
@@ -57,77 +66,119 @@ class TestStashLogicFunctions(unittest.TestCase):
         create_remote_branch,
     ):
         # Arrange:
-        mock_repo = Mock()
-        mock_repo.is_dirty = Mock(return_value=False)
-        mock_repo.untracked_files = True
+        self.repo = Mock()
+        self.repo.is_dirty = Mock(return_value=False)
+        self.repo.untracked_files = True
         defined_branch_in_file = "defined_branch_in_file"
         # Act:
-        uncommitted_branch_name, flag = self.switch(mock_repo, defined_branch_in_file)
+        uncommitted_branch_name, flag = self.switch(self.repo, defined_branch_in_file)
         # Assert:
-        create_remote_branch.assert_called_once_with(mock_repo, uncommitted_branch_name)
-        commit_to_local_temp_branch.assert_called_once_with(mock_repo)
-        preserve_uncommitted_code.assert_called_once_with(mock_repo)
-        create_local_temp_branch.assert_called_once_with(mock_repo, uncommitted_branch_name)
-        stash_local_changes.assert_called_once_with(mock_repo)
+        create_remote_branch.assert_called_once_with(self.repo, uncommitted_branch_name)
+        commit_to_local_temp_branch.assert_called_once_with(self.repo)
+        preserve_uncommitted_code.assert_called_once_with(self.repo)
+        create_local_temp_branch.assert_called_once_with(self.repo, uncommitted_branch_name)
+        stash_local_changes.assert_called_once_with(self.repo)
         self.assertTrue(uncommitted_branch_name.startswith(UNCOMMITTED_BRANCH_NAME))
 
     @patch.object(branch_utils, "checkout_remote_branch")
     @patch.object(branch_utils, "revert_from_uncommitted_code")
     def test_revert_from_temp_branch(self, revert_from_uncommitted_code, checkout_remote_branch):
         # Arrange:
-        mock_repo = Mock()
+        self.repo = Mock()
         active_branch = "active_branch"
         # Act:
-        self.revert(mock_repo, active_branch, True)
+        self.revert(self.repo, active_branch, True)
         # Assert:
         checkout_remote_branch.assert_called_once_with(
-            mock_repo,
+            self.repo,
             active_branch,
         )
-        revert_from_uncommitted_code.assert_called_once_with(mock_repo)
+        revert_from_uncommitted_code.assert_called_once_with(self.repo)
 
     def test_examine_blueprint_working_branch_detached(self):
         # Arrange:
-        mock_repo = Mock()
+        self.repo = Mock()
         mock_blueprint = Mock()
-        mock_repo.is_repo_detached = Mock(return_value=True)
+        self.repo.is_repo_detached = Mock(return_value=True)
 
         # Act & Assert:
-        self.assertRaises(BadBlueprintRepo, self.examine, mock_repo, mock_blueprint)
+        self.assertRaises(BadBlueprintRepo, self.examine, self.repo, mock_blueprint)
 
     def test_examine_blueprint_working_branch_attached(self):
         # Arrange:
-        mock_repo = Mock()
+        self.repo = Mock()
         mock_blueprint = Mock()
-        mock_repo.is_repo_detached = Mock(return_value=False)
+        self.repo.is_repo_detached = Mock(return_value=False)
 
         # Act:
-        self.examine(mock_repo, mock_blueprint)
+        self.examine(self.repo, mock_blueprint)
 
         # Assert:
-        mock_repo.is_dirty.assert_called_once()
-        mock_repo.is_current_branch_exists_on_remote()
-        mock_repo.is_current_branch_synced()
+        self.repo.is_dirty.assert_called_once()
+        self.repo.is_current_branch_exists_on_remote()
+        self.repo.is_current_branch_synced()
 
-    @freeze_time(datetime.now())
+    @patch('time.sleep', return_value=None)
     @patch("colony.branch_utils.is_k8s_blueprint")
     @patch("colony.branch_utils.can_temp_branch_be_deleted")
     @patch("colony.branch_utils.delete_temp_branch")
-    def test_wait_and_delete_temp_branch_not_k8s(self, delete_temp_branch, can_temp, is_k8s_blueprint):
+    def test_wait_and_delete_temp_branch_final_stage(self, delete_temp_branch, can_temp, is_k8s, time_sleep):
         # Arrange:
-        mock_repo = Mock()
-        mock_sb_manager = Mock()
-        mock_sandbox = Mock()
-        mock_sb_manager.get.return_value = mock_sandbox
-        mock_sandbox_id = Mock()
-        mock_temp_branch = "mock_temp_branch"
-        mock_blueprint_name = "mock_blueprint_name"
-
-        is_k8s_blueprint.return_value = False
+        self.initialize_mock_vars()
         can_temp.return_value = False
+        is_k8s.return_value = False
 
         # Act & assert:
         for final_stage in FINAL_SB_STATUSES:
-            mock_sandbox.sandbox_status = final_stage
-            self.wait_and_delete(mock_sb_manager, mock_sandbox_id, mock_repo, mock_temp_branch, mock_blueprint_name)
-            delete_temp_branch.assert_called_with(mock_repo, mock_temp_branch)
+            self.sandbox.sandbox_status = final_stage
+            start_time = datetime.now()
+            self.wait_and_delete(self.sb_manager, self.sandbox_id, self.repo, self.temp_branch, self.blueprint_name)
+            assert (datetime.now() - start_time).seconds < TIMEOUT * 60
+            delete_temp_branch.assert_called_with(self.repo, self.temp_branch)
+
+    @patch('time.sleep', return_value=None)
+    @patch("colony.branch_utils.is_k8s_blueprint")
+    @patch("colony.branch_utils.can_temp_branch_be_deleted")
+    @patch("colony.branch_utils.delete_temp_branch")
+    def test_wait_and_delete_temp_branch_can_be_deleted(self, delete_temp_branch, can_temp, is_k8s, time_sleep):
+        # Arrange:
+        self.initialize_mock_vars()
+        mock_non_final_stage = "mock_non_final_stage"
+        can_temp.return_value = True
+        is_k8s.return_value = False
+        self.sandbox.sandbox_status = mock_non_final_stage
+        start_time = datetime.now()
+
+        # Act:
+        self.wait_and_delete(self.sb_manager, self.sandbox_id, self.repo, self.temp_branch, self.blueprint_name)
+
+        # Assert:
+        assert (datetime.now() - start_time).seconds < TIMEOUT * 60
+        delete_temp_branch.assert_called_with(self.repo, self.temp_branch)
+
+    @patch("colony.branch_utils.TIMEOUT", 0)
+    @patch("time.sleep", return_value=None)
+    @patch("colony.branch_utils.is_k8s_blueprint")
+    @patch("colony.branch_utils.can_temp_branch_be_deleted")
+    @patch("colony.branch_utils.delete_temp_branch")
+    def test_wait_and_delete_temp_branch_cannot_be_deleted(
+        self,
+        delete_temp_branch,
+        can_temp,
+        is_k8s,
+        time_sleep,
+    ):
+        # Arrange:
+        self.initialize_mock_vars()
+        mock_non_final_stage = "mock_non_final_stage"
+        can_temp.return_value = False
+        is_k8s.return_value = False
+        self.sandbox.sandbox_status = mock_non_final_stage
+        start_time = datetime.now()
+
+        # Act:
+        self.wait_and_delete(self.sb_manager, self.sandbox_id, self.repo, self.temp_branch, self.blueprint_name)
+
+        # Assert:
+        assert (datetime.now() - start_time).microseconds > 0
+        delete_temp_branch.assert_called_with(self.repo, self.temp_branch)

--- a/tests/test_branch_utils.py
+++ b/tests/test_branch_utils.py
@@ -110,21 +110,24 @@ class TestStashLogicFunctions(unittest.TestCase):
         mock_repo.is_current_branch_synced()
 
     @freeze_time(datetime.now())
-    @patch.object(branch_utils, "is_k8s_blueprint")
-    @patch.object(branch_utils, "can_temp_branch_be_deleted")
-    @patch.object(branch_utils, "delete_temp_branch")
+    @patch("colony.branch_utils.is_k8s_blueprint")
+    @patch("colony.branch_utils.can_temp_branch_be_deleted")
+    @patch("colony.branch_utils.delete_temp_branch")
     def test_wait_and_delete_temp_branch_not_k8s(self, delete_temp_branch, can_temp, is_k8s_blueprint):
         # Arrange:
+        mock_repo = Mock()
         mock_sb_manager = Mock()
-        mock_sandbox_id = "mock_sandbox_id"
+        mock_sandbox = Mock()
+        mock_sb_manager.get.return_value = mock_sandbox
+        mock_sandbox_id = Mock()
         mock_temp_branch = "mock_temp_branch"
         mock_blueprint_name = "mock_blueprint_name"
 
-        is_k8s_blueprint = Mock(return_value=False)
-        can_temp = Mock(return_value=False)
+        is_k8s_blueprint.return_value = False
+        can_temp.return_value = False
 
         # Act & assert:
         for final_stage in FINAL_SB_STATUSES:
-            mock_repo = Mock(sandbox_status=final_stage)
+            mock_sandbox.sandbox_status = final_stage
             self.wait_and_delete(mock_sb_manager, mock_sandbox_id, mock_repo, mock_temp_branch, mock_blueprint_name)
             delete_temp_branch.assert_called_with(mock_repo, mock_temp_branch)

--- a/tests/test_branch_utils.py
+++ b/tests/test_branch_utils.py
@@ -92,10 +92,7 @@ class TestStashLogicFunctions(unittest.TestCase):
         mock_blueprint = Mock()
         mock_repo.is_repo_detached = Mock(return_value=True)
 
-        # Act:
-        #self.examine(mock_repo,mock_blueprint)
-
-        # Assert:
+        # Act & Assert:
         self.assertRaises(BadBlueprintRepo, self.examine, mock_repo, mock_blueprint)
 
     def test_examine_blueprint_working_branch_attached(self):
@@ -105,7 +102,7 @@ class TestStashLogicFunctions(unittest.TestCase):
         mock_repo.is_repo_detached = Mock(return_value=False)
 
         # Act:
-        self.examine(mock_repo,mock_blueprint)
+        self.examine(mock_repo, mock_blueprint)
 
         # Assert:
         mock_repo.is_dirty.assert_called_once()


### PR DESCRIPTION
Branch Utils:
-Added "try" to catch exception when K8S is not up
-Added a check to see if blueprint is K8S so temp branch doesn't get deleted ahead of time
sb:
removed the check for "if it is temp branch" from wait_and_then_delete
renamed it (to wait_and_delete_temp_branch) and added the check before calling it