### PR TITLE
Fix to K8S statuses

### DIFF
--- a/colony/branch_utils.py
+++ b/colony/branch_utils.py
@@ -217,7 +217,7 @@ def wait_and_delete_temp_branch(
 
         with yaspin(text="Starting...", color="yellow") as spinner:
             while (datetime.datetime.now() - start_time).seconds < TIMEOUT * 60:
-                if (status in FINAL_SB_STATUSES) or can_temp_branch_be_deleted(sandbox, k8s_blueprint):
+                if (status in FINAL_SB_STATUSES) or (not k8s_blueprint and can_nonk8s_temp_branch_be_deleted(sandbox)):
                     spinner.green.ok("✔")
                     break
 
@@ -271,19 +271,8 @@ def revert_wait_and_delete_temp_branch(
         wait_and_delete_temp_branch(manager, sandbox_id, repo, temp_working_branch, blueprint_name)
 
 
-def can_temp_branch_be_deleted(sandbox: Sandbox, k8s_blueprint: bool) -> bool:
+def can_nonk8s_temp_branch_be_deleted(sandbox: Sandbox) -> bool:
     progress = getattr(sandbox, "launching_progress")
     prep_artifacts_status = progress.get("preparing_artifacts").get("status")
-    deploy_app_status = progress.get("deploying_applications").get("status")
-    creating_infra_status = progress.get("creating_infrastructure").get("status")
 
-    k8s_sb_done_statuses = (
-        creating_infra_status == DONE_STATUS
-        and prep_artifacts_status == DONE_STATUS
-        and deploy_app_status == DONE_STATUS
-    )
-
-    if k8s_blueprint:
-        return k8s_sb_done_statuses
-    else:
-        return prep_artifacts_status == DONE_STATUS
+    return prep_artifacts_status == DONE_STATUS

--- a/tests/test_branch_utils.py
+++ b/tests/test_branch_utils.py
@@ -120,7 +120,7 @@ class TestStashLogicFunctions(unittest.TestCase):
 
     @patch("time.sleep", return_value=None)
     @patch("colony.branch_utils.is_k8s_blueprint")
-    @patch("colony.branch_utils.can_temp_branch_be_deleted")
+    @patch("colony.branch_utils.can_nonk8s_temp_branch_be_deleted")
     @patch("colony.branch_utils.delete_temp_branch")
     def test_wait_and_delete_temp_branch_final_stage(self, delete_temp_branch, can_temp, is_k8s, time_sleep):
         # Arrange:
@@ -138,7 +138,7 @@ class TestStashLogicFunctions(unittest.TestCase):
 
     @patch("time.sleep", return_value=None)
     @patch("colony.branch_utils.is_k8s_blueprint")
-    @patch("colony.branch_utils.can_temp_branch_be_deleted")
+    @patch("colony.branch_utils.can_nonk8s_temp_branch_be_deleted")
     @patch("colony.branch_utils.delete_temp_branch")
     def test_wait_and_delete_temp_branch_can_be_deleted(self, delete_temp_branch, can_temp, is_k8s, time_sleep):
         # Arrange:
@@ -159,7 +159,7 @@ class TestStashLogicFunctions(unittest.TestCase):
     @patch("colony.branch_utils.TIMEOUT", 0)
     @patch("time.sleep", return_value=None)
     @patch("colony.branch_utils.is_k8s_blueprint")
-    @patch("colony.branch_utils.can_temp_branch_be_deleted")
+    @patch("colony.branch_utils.can_nonk8s_temp_branch_be_deleted")
     @patch("colony.branch_utils.delete_temp_branch")
     def test_wait_and_delete_temp_branch_cannot_be_deleted(
         self,

--- a/tests/test_branch_utils.py
+++ b/tests/test_branch_utils.py
@@ -119,14 +119,14 @@ class TestStashLogicFunctions(unittest.TestCase):
         self.repo.is_current_branch_synced()
 
     @patch("time.sleep", return_value=None)
-    @patch("colony.branch_utils.is_k8s_blueprint")
-    @patch("colony.branch_utils.can_nonk8s_temp_branch_be_deleted")
+    @patch("colony.branch_utils.is_tf_blueprint")
+    @patch("colony.branch_utils.can_nontf_temp_branch_be_deleted")
     @patch("colony.branch_utils.delete_temp_branch")
-    def test_wait_and_delete_temp_branch_final_stage(self, delete_temp_branch, can_temp, is_k8s, time_sleep):
+    def test_wait_and_delete_temp_branch_final_stage(self, delete_temp_branch, can_temp, is_tf, time_sleep):
         # Arrange:
         self.initialize_mock_vars()
         can_temp.return_value = False
-        is_k8s.return_value = False
+        is_tf.return_value = False
 
         # Act & assert:
         for final_stage in FINAL_SB_STATUSES:
@@ -137,15 +137,15 @@ class TestStashLogicFunctions(unittest.TestCase):
             delete_temp_branch.assert_called_with(self.repo, self.temp_branch)
 
     @patch("time.sleep", return_value=None)
-    @patch("colony.branch_utils.is_k8s_blueprint")
-    @patch("colony.branch_utils.can_nonk8s_temp_branch_be_deleted")
+    @patch("colony.branch_utils.is_tf_blueprint")
+    @patch("colony.branch_utils.can_nontf_temp_branch_be_deleted")
     @patch("colony.branch_utils.delete_temp_branch")
-    def test_wait_and_delete_temp_branch_can_be_deleted(self, delete_temp_branch, can_temp, is_k8s, time_sleep):
+    def test_wait_and_delete_temp_branch_can_be_deleted(self, delete_temp_branch, can_temp, is_tf, time_sleep):
         # Arrange:
         self.initialize_mock_vars()
         mock_non_final_stage = "mock_non_final_stage"
         can_temp.return_value = True
-        is_k8s.return_value = False
+        is_tf.return_value = False
         self.sandbox.sandbox_status = mock_non_final_stage
         start_time = datetime.now()
 
@@ -158,21 +158,21 @@ class TestStashLogicFunctions(unittest.TestCase):
 
     @patch("colony.branch_utils.TIMEOUT", 0)
     @patch("time.sleep", return_value=None)
-    @patch("colony.branch_utils.is_k8s_blueprint")
-    @patch("colony.branch_utils.can_nonk8s_temp_branch_be_deleted")
+    @patch("colony.branch_utils.is_tf_blueprint")
+    @patch("colony.branch_utils.can_nontf_temp_branch_be_deleted")
     @patch("colony.branch_utils.delete_temp_branch")
     def test_wait_and_delete_temp_branch_cannot_be_deleted(
         self,
         delete_temp_branch,
         can_temp,
-        is_k8s,
+        is_tf,
         time_sleep,
     ):
         # Arrange:
         self.initialize_mock_vars()
         mock_non_final_stage = "mock_non_final_stage"
         can_temp.return_value = False
-        is_k8s.return_value = False
+        is_tf.return_value = False
         self.sandbox.sandbox_status = mock_non_final_stage
         start_time = datetime.now()
 


### PR DESCRIPTION
As in case of K8s_bp we have to wait for the SB to fully be deployed the function will only be used for non-k8s blueprints